### PR TITLE
fix: Allow to configure deface

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,6 +559,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -852,6 +854,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/decidim/custom_proposal_states.rb
+++ b/lib/decidim/custom_proposal_states.rb
@@ -3,11 +3,13 @@
 require "decidim/custom_proposal_states/admin"
 require "decidim/custom_proposal_states/engine"
 require "decidim/custom_proposal_states/admin_engine"
-
+require "byebug"
 module Decidim
   # This namespace holds the logic of the `CustomProposalStates` component. This component
   # allows users to create custom_proposal_states in a participatory space.
   module CustomProposalStates
+    include ActiveSupport::Configurable
+
     module Overrides
       autoload :Proposal, "decidim/custom_proposal_states/overrides/proposal"
       autoload :ImportProposalsToBudgets, "decidim/custom_proposal_states/overrides/import_proposals_to_budgets"
@@ -26,6 +28,10 @@ module Decidim
       autoload :ProposalCellsHelper, "decidim/custom_proposal_states/overrides/proposal_cells_helper"
       autoload :ProposalsController, "decidim/custom_proposal_states/overrides/proposals_controller"
       autoload :ProposalSearch, "decidim/custom_proposal_states/overrides/proposal_search"
+    end
+
+    config_accessor :deface_enabled do
+      ENV.fetch("DEFACE_ENABLED", "true") == "true"
     end
 
     def self.module_installed?(mod)

--- a/lib/decidim/custom_proposal_states.rb
+++ b/lib/decidim/custom_proposal_states.rb
@@ -31,7 +31,7 @@ module Decidim
     end
 
     config_accessor :deface_enabled do
-      ENV.fetch("DEFACE_ENABLED", "true") == "true"
+      ENV.fetch("DEFACE_ENABLED", nil) == "true"
     end
 
     def self.module_installed?(mod)

--- a/lib/decidim/custom_proposal_states.rb
+++ b/lib/decidim/custom_proposal_states.rb
@@ -3,7 +3,7 @@
 require "decidim/custom_proposal_states/admin"
 require "decidim/custom_proposal_states/engine"
 require "decidim/custom_proposal_states/admin_engine"
-require "byebug"
+
 module Decidim
   # This namespace holds the logic of the `CustomProposalStates` component. This component
   # allows users to create custom_proposal_states in a participatory space.

--- a/lib/decidim/custom_proposal_states.rb
+++ b/lib/decidim/custom_proposal_states.rb
@@ -31,7 +31,7 @@ module Decidim
     end
 
     config_accessor :deface_enabled do
-      ENV.fetch("DEFACE_ENABLED", nil) == "true"
+      ENV.fetch("DEFACE_ENABLED", nil) == "true" || Rails.env.test?
     end
 
     def self.module_installed?(mod)

--- a/lib/decidim/custom_proposal_states/engine.rb
+++ b/lib/decidim/custom_proposal_states/engine.rb
@@ -19,7 +19,7 @@ module Decidim
 
       initializer "decidim_custom_proposal_states.views" do
         Rails.application.configure do
-          config.deface.enabled = true
+          config.deface.enabled = Decidim::CustomProposalStates.deface_enabled
         end
       end
 


### PR DESCRIPTION
#### Description

This PR adds a `config_accessor` to activate / deactivate deface. By default, it uses env var `DEFACE_ENABLED` and it is set to true by default.

This config accessor allows to set Deface to false at runtime when views are precompiled

#### Fixes

Fixes #29 